### PR TITLE
Added composer definition file so that this can be added to Packagist.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "tobiaszcudnik/phpquery",
+    "description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery.",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Tobiasz Cudnik",
+            "email": "tobiasz.cudnik@gmail.com"
+        }
+    ],
+    "require": {
+
+    }
+}


### PR DESCRIPTION
See http://getcomposer.org and http://packagist.org.

This PHP package management tool is becoming increasingly popular across a number of major PHP projects, such as Drupal and Symfony (as well as a project I'm involved with, SilverStripe).

It would be great if you are interested in adding phpQuery to Packagist, or, if you prefer, I could list my fork of phpQuery in Packagist myself.

I'm not sure if you'd want to keep this change in GitHub, or submit it back to your SVN repository.  Packagist is able to connect to svn repos as well as git, but I haven't tried that myself.
