### PR TITLE
Remove controls characters from input HTML

### DIFF
--- a/phpQuery/phpQuery.php
+++ b/phpQuery/phpQuery.php
@@ -32,8 +32,8 @@ require_once(dirname(__FILE__).'/phpQuery/compat/mbstring.php');
  */
 abstract class phpQuery {
 	/**
-	 * XXX: Workaround for mbstring problems 
-	 * 
+	 * XXX: Workaround for mbstring problems
+	 *
 	 * @var bool
 	 */
 	public static $mbstringSupport = true;
@@ -270,6 +270,7 @@ abstract class phpQuery {
 	public static function newDocument($markup = null, $contentType = null) {
 		if (! $markup)
 			$markup = '';
+		$markup = preg_replace('/[\x00-\x1F\x7F]/', '', $markup);
 		$documentID = phpQuery::createDocumentWrapper($markup, $contentType);
 		return new phpQueryObject($documentID);
 	}


### PR DESCRIPTION
There is a problem with control characters for server with libxml 2.6.7 (most of current Linux) servers. In some cases HTML become incorrect (extra closing/opening body/html tags added):

Input:

~~~
string(128) "<html><head><meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
</head></body><b>BEL</b><b>normal</b></body></html>"
~~~
Output:

~~~
string(250) "<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0
Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
<html>
<head><meta http-equiv="Content-Type"
content="text/html;charset=UTF-8"></head>
<body><b></b></body>
<html><b>normal</b></html>
</html>
"
~~~